### PR TITLE
Enable tls credential shell

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -65,6 +65,11 @@ CONFIG_MBEDTLS_MEMORY_DEBUG=y
 CONFIG_MBEDTLS_SHELL=y
 CONFIG_MBEDTLS_AES_ROM_TABLES=y
 
+# Credential shell, useful for debug
+CONFIG_TLS_CREDENTIALS_SHELL=y
+# Required for TLS crediential shell
+CONFIG_BASE64=y
+
 # More verbose Memfault component logs
 CONFIG_MEMFAULT_LOG_LEVEL_DBG=y
 


### PR DESCRIPTION
Adds about 6kB of code space :face_exhaling: but it's somewhat useful, though the esp32s3 shows some errors:

```bash
uart:~$ cred list
1001,CA,ERROR,-134
1002,CA,ERROR,-134
1003,CA,ERROR,-134
```