### PR TITLE
Build for esp32c3, update memfault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,17 @@ jobs:
         run: |
           cd zephyr-workspace
           ccache -z
+
           west build --sysbuild \
             --pristine=always \
             --board=esp32s3_devkitm zephyr-esp32-example \
             -- \
             -DCONFIG_MEMFAULT_PROJECT_KEY=\"1234\"
+
           west build --sysbuild \
             --pristine=always \
-            --board=esp32s3_devkitm zephyr-esp32-example \
+            --board=esp32c3_devkitm zephyr-esp32-example \
             -- \
             -DCONFIG_MEMFAULT_PROJECT_KEY=\"1234\"
+
           ccache -sv

--- a/west.yml
+++ b/west.yml
@@ -1,13 +1,7 @@
 manifest:
-  remotes:
-    - name: zephyrproject-rtos
-      url-base: https://github.com/zephyrproject-rtos
-    - name: memfault
-      url-base: https://github.com/memfault
-
   projects:
     - name: zephyr
-      remote: zephyrproject-rtos
+      url: https://github.com/zephyrproject-rtos/zephyr
       revision: v3.6.0
       import:
         # Limit the Zephyr modules to the required set
@@ -17,6 +11,6 @@ manifest:
           - mcuboot
 
     - name: memfault-firmware-sdk
+      url: https://github.com/memfault/memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      remote: memfault
-      revision: 1.9.2
+      revision: 1.10.1


### PR DESCRIPTION
Fix a typo so we actually build for the C3.
Update memfault to 1.10.1.
