### PR TITLE
Update to zephyr v4.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -2,7 +2,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: v4.1.0
+      revision: v4.2.0
       import:
         # Limit the Zephyr modules to the required set
         name-allowlist:
@@ -13,4 +13,4 @@ manifest:
     - name: memfault-firmware-sdk
       url: https://github.com/memfault/memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.26.1
+      revision: 1.28.0


### PR DESCRIPTION
Spot checked with:

```bash
❯ west build --sysbuild --pristine -b esp_wrover_kit/esp32/procpu zephyr-esp32-example -- -DCONFIG_MEMFAULT_PROJECT_KEY=\"$(<~/.memfault-noah-test-project-key)\" -DCONFIG_MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS=120 -DCONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD_INTERVAL_SECS=120
```

Seems ok to me!
