### PR TITLE
Esp32s3-devkitm board was removed (consolidated) in zephyr 4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
 
       - name: ♻️ Setup Zephyr project
         uses: zephyrproject-rtos/action-zephyr-setup@v1

--- a/sample.yaml
+++ b/sample.yaml
@@ -2,7 +2,6 @@ common:
   tags: memfault
   platform_allow:
     - esp_wrover_kit/esp32/procpu
-    - esp32s3_devkitm/esp32s3/procpu
     - esp32s3_devkitc/esp32s3/procpu
     - esp32c3_devkitm
     - esp32c6_devkitc/esp32c6/hpcore


### PR DESCRIPTION
There's still a build error on esp32c3, which I am fixing in the Memfault SDK:

```bash
undefined reference to `rv_utils_dbgr_is_attached'
```