### PR TITLE
fix: app_version.h is namespaced in zephyr > 4.4.0

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2,13 +2,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <zephyr/app_version.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/wifi_mgmt.h>
 
-#include "app_version.h"
 #include "memfault/components.h"
 #include "memfault/ports/zephyr/core.h"
 #include "memfault/ports/zephyr/http.h"

--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,4 @@ manifest:
     - name: memfault-firmware-sdk
       url: https://github.com/memfault/memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      # temporary branch for PSA sha1 workaround.
-      revision: noahp/1.40.0-rc1
+      revision: 1.42.0


### PR DESCRIPTION
Need the namespacing in the generated include path:

https://github.com/zephyrproject-rtos/zephyr/commit/d78bf6c165807aa4a642eab748022bc7306a6011
