### PR TITLE
Remove override of Memfault Zephyr data region names

### DIFF
--- a/config/memfault_platform_config.h
+++ b/config/memfault_platform_config.h
@@ -10,11 +10,6 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_MEMFAULT_SOC_FAMILY_ESP32)
-  #define ZEPHYR_DATA_REGION_START _data_start
-  #define ZEPHYR_DATA_REGION_END _data_end
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/west.yml
+++ b/west.yml
@@ -14,4 +14,4 @@ manifest:
     - name: memfault-firmware-sdk
       url: https://github.com/memfault/memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.42.0
+      revision: 1.42.1


### PR DESCRIPTION
It's native in the SDK as of v1.42.1
